### PR TITLE
AudioBugfix for Samsung/Android Browser

### DIFF
--- a/modules/mojo/native/mojo.html5.js
+++ b/modules/mojo/native/mojo.html5.js
@@ -496,7 +496,11 @@ gxtkAudio.prototype.PlaySample=function( buffer,channel,flags ){
 	
 	if( chan.state ){
 		chan.waSource.onended=null
-		chan.waSource.stop( 0 );
+		try {
+			chan.waSource.stop( 0 );
+			chan.state = 0			
+		} catch (err) {			
+		}
 	}
 	
 	chan.buffer=buffer;
@@ -527,7 +531,10 @@ gxtkAudio.prototype.StopChannel=function( channel ){
 	
 	if( chan.state==1 ){
 		chan.waSource.onended=null;
-		chan.waSource.stop( 0 );
+		try {
+			chan.waSource.stop( 0 );
+		} catch (err) {			
+		}
 		chan.waSource=null;
 	}
 
@@ -542,7 +549,10 @@ gxtkAudio.prototype.PauseChannel=function( channel ){
 	chan.offset=(chan.offset+(wa.currentTime-chan.startTime)*chan.rate)%chan.buffer.waBuffer.duration;
 	
 	chan.waSource.onended=null;
-	chan.waSource.stop( 0 );
+	try {
+		chan.waSource.stop( 0 );
+	} catch (err) {			
+	}
 	chan.waSource=null;
 	
 	chan.state=2;


### PR DESCRIPTION
On Samsung Devices (on my Galaxy S4Mini) playing a sound effect
sometimes results in a crash, throwing the following Exception:

InvalidStateError: DOM Exception 11

I've found out that it could happen that chan.waSource.stop( 0 )
throws this exception. However, as far as I understand the source,
this happens if stop is called twice or when waSource Object
isn't playing. So this if-branch shouldn't be reached, but it does.

I've fixed it by catching the exception and ignoring it, which is
fine in this case.

I'm sure there must be a more cleaner solution, but I wasn't
able to find one. This fix worked fine for me.