### PR TITLE
Reset Method for List Enumerator

### DIFF
--- a/modules/monkey/list.monkey
+++ b/modules/monkey/list.monkey
@@ -340,6 +340,10 @@ Class Enumerator<T>
 		Return data
 	End
 
+	 Method Reset:Void()
+		_curr = _list._head._succ
+	 End
+ 
 Private
 	
 	Field _list:List<T>


### PR DESCRIPTION
Monkey X currently creates a new List Enumerator for every enumaration.
When working with many Lists this behavior creates a lot of garbage.
It would be nice if the Enumator object could be reset to allow reuse in performance sensitive parts of the application.