### PR TITLE
Optimised GetDecl process for faster semanting across multiple files

### DIFF
--- a/VERSIONS.TXT
+++ b/VERSIONS.TXT
@@ -1,4 +1,20 @@
 
+***** v85b *****
+
+Applied Xaron's fix for HttpRequest on winrt.
+
+Changed android string->int/float conversion to native code to prevent 'number format exceptions'.
+
+
+***** v85a *****
+
+Mojo2 now inits itself properly.
+
+Fixed vectormonkey so it uses LoadString instead of an inline mega-string.
+
+Fixed angle target so spaces in project path work.
+
+
 ***** v84e *****
 
 Fixed issue with Mojo2 html5 texture loading.

--- a/modules/monkey/map.monkey
+++ b/modules/monkey/map.monkey
@@ -141,6 +141,14 @@ Class Map<K,V>
 		Return node
 	End
 	
+	Method Clone(from:Map<K, V>)
+		If Not from.root
+			root = Null
+			Return
+		EndIf
+		root = from.root.Copy(Null)
+	End
+	
 	'Deprecated - use Set
 	Method Insert:Bool( key:K,value:V )
 		Return Set( key,value )

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -1273,9 +1273,10 @@ End
 Class ModuleDecl Extends ScopeDecl
 
 	Global master_uid:Int = 0
-
+	Global master_im_version:Int = 1
+	
 	Field uid:Int = 0
-	Field indirectMapsPrepped:Bool = False
+	Field indirectMapsVersion:Int = 0
 	Field indirectDeclMapPublicOnly:= New StringMap<SynonymList>
 	Field indirectDeclMapPublicPrivate:= New StringMap<SynonymList>
 	Field accessibleModuleScopesPublic:= New IntMap<ModuleDecl>
@@ -1379,7 +1380,7 @@ Class ModuleDecl Extends ScopeDecl
 		accessibleModuleScopesPublic = New IntMap<ModuleDecl>
 		accessibleModuleScopesPublicPrivate = New IntMap<ModuleDecl>
 		
-		indirectMapsPrepped = True
+		indirectMapsVersion = master_im_version
 		Local todo:= New List<ModuleDecl>
 		Local accListPublic:List<ModuleDecl> = New List<ModuleDecl>
 		Local accListPublicPrivate:List<ModuleDecl> = New List<ModuleDecl>
@@ -1504,7 +1505,7 @@ Class ModuleDecl Extends ScopeDecl
 			'Print "Done."
 		Else
 			If accessibleModuleScopesPublic.Contains(mdecl.uid)
-				If Not mdecl.indirectMapsPrepped
+				If mdecl.indirectMapsVersion < master_im_version
 					mdecl.BuildIndirectDeclMaps()
 				EndIf
 				'AC: The _env's own module scope is accessible from here.
@@ -1703,6 +1704,15 @@ Class ModuleDecl Extends ScopeDecl
 		attrs|=MODULE_SEMANTALL
 	End
 	
+	Method InsertDecl(decl:Decl)
+		Super.InsertDecl(decl)
+		master_im_version += 1
+	End
+
+	Method InsertDecls(decls:List<Decl>)
+		Super.InsertDecls(decls)
+		master_im_version += 1
+	End
 End
 
 Class AppDecl Extends ScopeDecl

--- a/modules/trans/decl.monkey
+++ b/modules/trans/decl.monkey
@@ -368,6 +368,9 @@ End
 
 Class ScopeDecl Extends Decl
 
+	Global GetDecl_Fail:Int
+	Global GetDecl_Success:Int
+
 Private
 
 	Field decls:=New List<Decl>
@@ -1484,13 +1487,14 @@ Class ModuleDecl Extends ScopeDecl
 	
 	Method GetDecl:Object(ident:String)
 	
-		If Not indirectMapsPrepped
+		If indirectMapsVersion < master_im_version
 			'Print "Building IDMs for " + Self.ident + "..."
 			BuildIndirectDeclMaps()
 			'Print "Done."
 		EndIf
 		
 		If Not _env
+			'AC: 'Slow' version probably quicker in this case as it's a smaller stringmap.
 			Return GetDecl_Slow(ident)
 		EndIf
 		


### PR DESCRIPTION
Monkey X currently creates a new List Enumerator for every enumaration.
When working with many Lists this behavior creates a lot of garbage.
It would be nice if the Enumator object could be reset to allow reuse in performance sensitive parts of the application.